### PR TITLE
Update plugin so it can be tested independently

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -47,7 +47,6 @@ define rbenv::plugin(
     path    => [ '/usr/bin' ],
     onlyif  => "test -d ${install_dir}/plugins",
     unless  => "test -d ${install_dir}/plugins/${plugin[1]}",
-    require => Class['git'],
   }~>
   exec { "rbenv-permissions-${name}":
     command     => "chown -R ${owner}:${group} ${install_dir} && \

--- a/tests/plugin.pp
+++ b/tests/plugin.pp
@@ -1,3 +1,6 @@
 class { 'git': }
 class { 'rbenv': }
-rbenv::plugin { 'sstephenson/ruby-build': }
+
+rbenv::plugin { 'sstephenson/ruby-build':
+  require => Class['git'],
+}

--- a/tests/rbenv-vars.pp
+++ b/tests/rbenv-vars.pp
@@ -1,3 +1,5 @@
 class { 'git': }
 class { 'rbenv': }
-rbenv::plugin { 'sstephenson/rbenv-vars': }
+rbenv::plugin { 'sstephenson/rbenv-vars':
+  require => Class['git'],
+}


### PR DESCRIPTION
After these small changes, this now works:

```
Vagrant::Config.run do |config|
  config.vm.box     = 'precise64'
  ...
  config.vm.provision :puppet do |puppet|
  puppet.manifests_path = "tests"
  puppet.manifest_file  = "plugin.pp"
  puppet.module_path = ["../", "tests/modules/"]
  end
end
```
