### PR TITLE
Fix deps for nokogiri in tests running on centos

### DIFF
--- a/tests/vagrant.pp
+++ b/tests/vagrant.pp
@@ -4,7 +4,12 @@ rbenv::plugin { 'sstephenson/ruby-build': }
 rbenv::plugin { 'sstephenson/rbenv-vars': }
 
 # these packages are required for nokogiri
-package { ['libxslt1-dev', 'libxml2-dev']: }->
+$nokogiri_deps = $::osfamily ? {
+  'RedHat' => ['libxslt-devel', 'libxml2-devel'],
+  default  => ['libxslt1-dev', 'libxml2-dev']
+}
+
+package { $nokogiri_deps: } ->
 rbenv::build { '2.0.0-p247': global => true }
 
 rbenv::gem { 'backup':


### PR DESCRIPTION
Fix package names for centos so the tests don't fail as early.  Because of #21 I wasn't able to get a successful test run.
