### PR TITLE
rbenv install fails on centos510

### DIFF
--- a/manifests/build.pp
+++ b/manifests/build.pp
@@ -79,7 +79,7 @@ define rbenv::build (
     require => Rbenv::Plugin['sstephenson/ruby-build'],
   }->
   exec { "rbenv-install-${title}":
-    command     => "rbenv install ${title}",
+    command     => "su -l -c 'rbenv install ${title}' - root",
     environment => $environment_for_build,
     creates     => "${install_dir}/versions/${title}",
   }~>


### PR DESCRIPTION
... with the following message:

```
notice: /Stage[main]//Rbenv::Build[1.9.3-p484]/Exec[git-pull-rubybuild-1.9.3-p484]/returns: executed successfully
notice: /Stage[main]//Rbenv::Build[1.9.3-p484]/Exec[git-pull-rubybuild-1.9.3-p484]: Triggered 'refresh' from 1 events
err: /Stage[main]//Rbenv::Build[1.9.3-p484]/Exec[rbenv-install-1.9.3-p484]/returns: change from notrun to 0 failed: rbenv install 1.9.3-p484 returned 1 instead of one of [0] at /tmp/vagrant-puppet-1/modules-0/rbenv/manifests/build.pp:85
err: /Stage[main]//Rbenv::Build[1.9.3-p484]/Exec[rbenv-install-1.9.3-p484]: Failed to call refresh: rbenv install 1.9.3-p484 returned 1 instead of one of [0] at /tmp/vagrant-puppet-1/modules-0/rbenv/manifests/build.pp:85
n
```

This can be easily reproduced by running a `vagrant ssh` and a `sudo rbenv install xxx`.  It seems like the shell spawned by sudo isn't reading `/etc/profile.d/rbenv.sh`.

Using su to spawn a new login shell seems to fix the problem.  Again, I wasn't able to get a clean run of the vagrant tests because of #21.
