### PR TITLE
Set the RBENV_ROOT environment variable for rbenv rehash

### DIFF
--- a/manifests/gem.pp
+++ b/manifests/gem.pp
@@ -72,6 +72,7 @@ define rbenv::gem(
   exec { "rbenv-rehash-${gem}-${ruby_version}":
     command     => "${install_dir}/bin/rbenv rehash",
     refreshonly => true,
+    environment => [ "RBENV_ROOT=${install_dir}" ],
   }~>
   exec { "rbenv-permissions-${gem}-${ruby_version}":
     command     => "/bin/chown -R ${rbenv::owner}:${rbenv::group} ${install_dir}/versions/${ruby_version}/lib/ruby/gems && /bin/chmod -R g+w ${install_dir}/versions/${ruby_version}/lib/ruby/gems",


### PR DESCRIPTION
If this variable isn't set, rbenv assumes we want to operate on .rbenv/
inside the root home directory.
