### PR TITLE
Patch support and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ you can set the Ruby to be the global interpreter.
 
     rbenv::plugin { 'sstephenson/ruby-build': }
     rbenv::build { '2.0.0-p247': global => true }
+    
+Sometimes Ruby needs to be patched prior to being compiled. puppet-rbenv
+currently supports patching from a single file located either on the
+Puppet Master or the local filesystem. Therefore, the only accepted paths are those
+starting with puppet:/// or file:///.
+
+    rbenv::build { '2.0.0-p247': patch => 'puppet:///modules/rbenv/patch.patch' }
+    rbenv::build { '2.0.0-p247': patch => 'file:///path/to/patch.patch' }
 
 ## Plugins
 Plugins can be installed from GitHub using the following definiton:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,16 +11,31 @@ Vagrant.configure("2") do |config|
     #config.vm.provision :shell, :inline => "sudo yum install -y openssl"
     centos.vm.provision :puppet do |puppet|
       puppet.manifests_path = "tests/vagrant"
+      # Tests patch since 1.9.2-p180 does not work by default on CentOS 7
+      #puppet.manifest_file  = "centos_patch.pp"
+      puppet.manifest_file  = "centos.pp"
+      puppet.options        = ["--modulepath", "/tmp/puppet-modules"]
+    end
+  end
+
+  config.vm.define "centos6" do |centos6|
+    centos6.vm.box     = 'puppetlabs/centos-6.6-64-puppet'
+    centos6.vm.provision :puppet do |puppet|
+      puppet.manifests_path = "tests/vagrant"
+      # Tests patch since 1.9.2-p180 does not work by default on CentOS 6.6 (Final)
+      #puppet.manifest_file  = "centos_patch.pp"
       puppet.manifest_file  = "centos.pp"
       puppet.options        = ["--modulepath", "/tmp/puppet-modules"]
     end
   end
 
   config.vm.define "debian", primary: true do |debian|
-    debian.vm.box     = 'puppetlabs/debian-7.6-64-puppet'
+    debian.vm.box     = 'puppetlabs/debian-7.8-64-puppet'
     debian.vm.provision :shell, :inline => 'apt-get update'
     debian.vm.provision :puppet do |puppet|
       puppet.manifests_path = "tests/vagrant"
+      # Tests patch since 1.9.2-p180 does not work by default on Debian 7.8
+      #puppet.manifest_file  = "ubuntu_patch.pp"
       puppet.manifest_file  = "ubuntu.pp"
       puppet.options        = ["--modulepath", "/tmp/puppet-modules"]
     end
@@ -31,6 +46,8 @@ Vagrant.configure("2") do |config|
     ubuntu.vm.provision :shell, :inline => 'aptitude update'
     ubuntu.vm.provision :puppet do |puppet|
       puppet.manifests_path = "tests/vagrant"
+      # Tests patch since 1.9.2-p180 does not work by default on Ubuntu
+      #puppet.manifest_file  = "ubuntu_patch.pp"
       puppet.manifest_file  = "ubuntu.pp"
       puppet.options        = ["--modulepath", "/tmp/puppet-modules"]
     end

--- a/spec/defines/build_spec.rb
+++ b/spec/defines/build_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'rbenv::build' do
   describe 'install 2.0.0-p247' do
     let(:title) { '2.0.0-p247' }
-    let(:facts) { { :osfamily => 'Debian' } }
+    let(:facts) { { :osfamily => 'Debian', :vardir => '/var/lib/puppet' } }
     let(:params) do
       {
         :install_dir => '/usr/local/rbenv',
@@ -20,6 +20,8 @@ describe 'rbenv::build' do
     it { should contain_exec("git-pull-rubybuild-2.0.0-p247") }
     it { should contain_exec("rbenv-install-2.0.0-p247") }
     it { should contain_exec("rbenv-ownit-2.0.0-p247") }
+    # Included to ensure bundler docs are skipped to avoid outdated rdoc error
+    it { should contain_rbenv__gem("bundler-2.0.0-p247").with({ 'skip_docs' => true }) }
 
     context 'with global => true' do
       let(:params) do
@@ -35,5 +37,42 @@ describe 'rbenv::build' do
       it { should contain_exec("rbenv-global-2.0.0-p247") }
     end
 
+    # Regex because we use ::settings::vardir which is a randomly
+    # named tmp directory in the tests
+    patch_cmd_regex = /rbenv install 2\.0\.0-p247 --patch < \/tmp\/[0-9a-z-]+\/rbenv\/2\.0\.0-p247\.patch/
+
+    context 'with patch => file:///path/to/patch.patch' do
+      let(:params) do
+        {
+          :patch => 'file:///path/to/patch.patch',
+        }
+      end
+
+      it { should contain_exec("rbenv-install-2.0.0-p247").with_command(patch_cmd_regex) }
+    end
+
+    context 'with patch => puppet:///modules/rbenv/patch.patch' do
+      let(:params) do
+        {
+          :patch => 'puppet:///modules/rbenv/patch.patch',
+        }
+      end
+
+      it { should contain_exec("rbenv-install-2.0.0-p247").with_command(patch_cmd_regex) }
+    end
+
+    context 'with invalid patch => http://example.com/patch.patch' do
+      let(:params) do
+        {
+          :patch => 'http://example.com/patch.patch',
+        }
+      end
+
+      it do
+        expect {
+          should contain_exec("rbenv-install-2.0.0-p247").with_command(patch_cmd_regex)
+        }.to raise_error(Puppet::Error, /Patch source invalid/)
+      end
+    end
   end
 end

--- a/tests/patches/1.9.2-p180_centos.patch
+++ b/tests/patches/1.9.2-p180_centos.patch
@@ -1,0 +1,88 @@
+From 0d58bb55985e787364b0235e5e69278d0f0ad4b0 Mon Sep 17 00:00:00 2001
+From: emboss <emboss@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+Date: Fri, 5 Jul 2013 22:46:42 +0000
+Subject: [PATCH] * ext/openssl/ossl_pkey_ec.c: Ensure compatibility to builds
+ of   OpenSSL with OPENSSL_NO_EC2M defined, but OPENSSL_NO_EC not   defined. *
+ test/openssl/test_pkey_ec.rb: Iterate over built-in curves   (and assert
+ their non-emptiness!) instead of hard-coding them, as   this may cause
+ problems with respect to the different availability   of individual curves in
+ individual OpenSSL builds.   [ruby-core:54881] [Bug #8384]
+
+  Thanks to Vit Ondruch for providing the patch!
+  Modified for 1.9.2-p180 by Prachetas Prabhu.
+
+
+git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@41808 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
+---
+ ext/openssl/ossl_pkey_ec.c   |  4 ++++
+ test/openssl/test_ec.rb | 22 +++++++++++++---------
+ 2 files changed, 17 insertions(+), 9 deletions(-)
+
+diff --git a/ext/openssl/ossl_pkey_ec.c b/ext/openssl/ossl_pkey_ec.c
+index 9d7607e..5e419bd 100644
+--- a/ext/openssl/ossl_pkey_ec.c
++++ b/ext/openssl/ossl_pkey_ec.c
+@@ -762,8 +762,10 @@ static VALUE ossl_ec_group_initialize(int argc, VALUE *argv, VALUE self)
+                 method = EC_GFp_mont_method();
+             } else if (id == s_GFp_nist) {
+                 method = EC_GFp_nist_method();
++#if !defined(OPENSSL_NO_EC2M)
+             } else if (id == s_GF2m_simple) {
+                 method = EC_GF2m_simple_method();
++#endif
+             }
+ 
+             if (method) {
+@@ -814,8 +816,10 @@ static VALUE ossl_ec_group_initialize(int argc, VALUE *argv, VALUE self)
+ 
+             if (id == s_GFp) {
+                 new_curve = EC_GROUP_new_curve_GFp;
++#if !defined(OPENSSL_NO_EC2M)
+             } else if (id == s_GF2m) {
+                 new_curve = EC_GROUP_new_curve_GF2m;
++#endif
+             } else {
+                 ossl_raise(rb_eArgError, "unknown symbol, must be :GFp or :GF2m");
+             }
+diff --git a/test/openssl/test_ec.rb b/test/openssl/test_ec.rb
+index f151335..56f3ff7 100644
+--- a/test/openssl/test_ec.rb
++++ b/test/openssl/test_ec.rb
+@@ -12,24 +12,28 @@ def setup
+     @data1 = 'foo'
+     @data2 = 'bar' * 1000 # data too long for DSA sig
+ 
+-    @group1 = OpenSSL::PKey::EC::Group.new('secp112r1')
+-    @group2 = OpenSSL::PKey::EC::Group.new('sect163k1')
++    @groups = []
++    @keys = []
+ 
+-    @key1 = OpenSSL::PKey::EC.new
+-    @key1.group = @group1
+-    @key1.generate_key
++    OpenSSL::PKey::EC.builtin_curves.each do |curve, comment|
++      group = OpenSSL::PKey::EC::Group.new(curve)
+ 
+-    @key2 = OpenSSL::PKey::EC.new(@group2.curve_name)
+-    @key2.generate_key
++      key = OpenSSL::PKey::EC.new(group)
++      key.generate_key
+ 
+-    @groups = [@group1, @group2]
+-    @keys = [@key1, @key2]
++      @groups << group
++      @keys << key
++    end
+   end
+ 
+   def compare_keys(k1, k2)
+     assert_equal(k1.to_pem, k2.to_pem)
+   end
+ 
++  def test_builtin_curves
++    assert(!OpenSSL::PKey::EC.builtin_curves.empty?)
++  end
++
+   def test_curve_names
+     @groups.each_with_index do |group, idx|
+       key = @keys[idx]

--- a/tests/patches/1.9.2-p180_ubuntu.patch
+++ b/tests/patches/1.9.2-p180_ubuntu.patch
@@ -1,0 +1,17 @@
+diff --git a/ext/openssl/ossl_ssl.c b/ext/openssl/ossl_ssl.c
+index e8d2e86..be62fcc 100644
+--- a/ext/openssl/ossl_ssl.c
++++ b/ext/openssl/ossl_ssl.c
+@@ -107,9 +107,12 @@ struct {
+     OSSL_SSL_METHOD_ENTRY(TLSv1),
+     OSSL_SSL_METHOD_ENTRY(TLSv1_server),
+     OSSL_SSL_METHOD_ENTRY(TLSv1_client),
++#if defined(HAVE_SSLV2_METHOD) && defined(HAVE_SSLV2_SERVER_METHOD) && \
++        defined(HAVE_SSLV2_CLIENT_METHOD)
+     OSSL_SSL_METHOD_ENTRY(SSLv2),
+     OSSL_SSL_METHOD_ENTRY(SSLv2_server),
+     OSSL_SSL_METHOD_ENTRY(SSLv2_client),
++#endif
+     OSSL_SSL_METHOD_ENTRY(SSLv3),
+     OSSL_SSL_METHOD_ENTRY(SSLv3_server),
+     OSSL_SSL_METHOD_ENTRY(SSLv3_client),

--- a/tests/vagrant/centos_patch.pp
+++ b/tests/vagrant/centos_patch.pp
@@ -1,0 +1,12 @@
+class { 'rbenv': group => $group }
+
+rbenv::plugin { 'sstephenson/ruby-build': }
+
+# CentOS 6.6 (Final) does not have patch installed by default
+package { 'patch':
+  ensure => 'installed',
+}->
+rbenv::build { '1.9.2-p180':
+  global => true,
+  patch => 'file:///tmp/puppet-modules/rbenv/tests/patches/1.9.2-p180_centos.patch',
+}

--- a/tests/vagrant/ubuntu_patch.pp
+++ b/tests/vagrant/ubuntu_patch.pp
@@ -1,0 +1,13 @@
+class { 'rbenv': group => $group }
+
+rbenv::plugin { 'sstephenson/ruby-build': }
+
+package { ['libxslt1-dev', 'libxml2-dev', 'libjemalloc1']: }->
+file { '/usr/lib/libjemalloc.so':
+  ensure => link,
+  target => '/usr/lib/libjemalloc.so.1',
+}->
+rbenv::build { '1.9.2-p180':
+  global => true,
+  patch => 'file:///tmp/puppet-modules/rbenv/tests/patches/1.9.2-p180_ubuntu.patch',
+}


### PR DESCRIPTION
#### What's this PR do?
Adds functionality, tests, documentation, and Vagrant setup for patching Ruby prior to compilation. Also skips docs on bundler install to avoid rdoc errors and updates debian boxfile (the 7.6 box was no longer available). All changes are commented and explained. Tested against CentOS 7, CentOS 6.6 (Final), Debian 7.8 and Ubuntu 14.04 LTS on the Vagrants.

#### Where should the reviewer start?
Begin in the manifests/build.pp file with the $patch variable validation.

#### How should this be tested?
By running `bundle exec rake spec` for the unit tests. Functional tests can be carried out by modifying the Vagrantfile to uncomment the centos_patch.pp and ubuntu_patch.pp manifest lines in each block (remember to comment centos.pp and ubuntu.pp lines). You can then run `vagrant up` and all of the boxes should provision with a patched version of 1.9.2-p180.

#### Any background context you want to provide?
At Railsdog we occasionally support/update legacy applications that use older versions of Ruby. We have found that there a lot of compatibility issues between libararies and Ruby and have had to patch things manually. We have had great success with puppet-rbenv in the past so I figured we should submit a PR!