### PR TITLE
Allow specification of bundler when building ruby

### DIFF
--- a/manifests/build.pp
+++ b/manifests/build.pp
@@ -48,13 +48,14 @@
 # Justin Downing <justin@downing.us>
 #
 define rbenv::build (
-  $install_dir = $rbenv::install_dir,
-  $owner       = $rbenv::owner,
-  $group       = $rbenv::group,
-  $global      = false,
-  $keep        = false,
-  $env         = [],
-  $patch       = undef,
+  $install_dir      = $rbenv::install_dir,
+  $owner            = $rbenv::owner,
+  $group            = $rbenv::group,
+  $global           = false,
+  $keep             = false,
+  $env              = [],
+  $patch            = undef,
+  $bundler_version  = '>=0',
 ) {
   include rbenv
 
@@ -146,6 +147,7 @@ define rbenv::build (
     gem          => 'bundler',
     ruby_version => $title,
     skip_docs    => true,
+    version      => $bundler_version,
   }
 
   if $global == true {

--- a/spec/defines/build_spec.rb
+++ b/spec/defines/build_spec.rb
@@ -6,11 +6,12 @@ describe 'rbenv::build' do
     let(:facts) { { :osfamily => 'Debian', :vardir => '/var/lib/puppet' } }
     let(:params) do
       {
-        :install_dir => '/usr/local/rbenv',
-        :owner       => 'root',
-        :group       => 'adm',
-        :global      => false,
-        :env         => ['RUBY_CFLAGS=-O3 -march=native'],
+        :install_dir      => '/usr/local/rbenv',
+        :owner            => 'root',
+        :group            => 'adm',
+        :global           => false,
+        :env              => ['RUBY_CFLAGS=-O3 -march=native'],
+        :bundler_version  => '>1.9',
       }
     end
 
@@ -21,7 +22,7 @@ describe 'rbenv::build' do
     it { should contain_exec("rbenv-install-2.0.0-p247") }
     it { should contain_exec("rbenv-ownit-2.0.0-p247") }
     # Included to ensure bundler docs are skipped to avoid outdated rdoc error
-    it { should contain_rbenv__gem("bundler-2.0.0-p247").with({ 'skip_docs' => true }) }
+    it { should contain_rbenv__gem("bundler-2.0.0-p247").with({ 'skip_docs' => true, 'version' => '>1.9' }) }
 
     context 'with global => true' do
       let(:params) do


### PR DESCRIPTION
Currently having to hack around rbenvs installation of bundler. Would prefer to just be able to specify the bundler version when specifying ruby version.