### PR TITLE
Make git package management optional

### DIFF
--- a/manifests/deps.pp
+++ b/manifests/deps.pp
@@ -11,7 +11,7 @@
 # Copyright 2013 Justin Downing
 #
 class rbenv::deps {
-  include ::git
+
   include ::stdlib
 
   case $::osfamily {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,8 +28,12 @@
 # [$latest]
 #   This defines whether the rbenv $install_dir is kept up-to-date.
 #   Defaults: false
-#   This vaiable is optional.
+#   This variable is optional.
 #
+# [$manage_git]
+#   This defines wehter the git module will actually install the git package
+#   Defaults: true
+#   This variable is optional
 # === Requires
 #
 # This module requires the following modules:
@@ -61,8 +65,13 @@ class rbenv (
   $owner       = 'root',
   $group       = $rbenv::deps::group,
   $latest      = false,
+  $manage_git  = true,
 ) inherits rbenv::deps {
   include rbenv::deps
+
+  class { ::git :
+    package_manage => $manage_git
+  }
 
   exec { 'git-clone-rbenv':
     command => "/usr/bin/git clone ${rbenv::repo_path} ${install_dir}",


### PR DESCRIPTION
For instances where git is managed elsewhere, include an optional parameter to let the git module know wether or not to manage the git package. The default for this parameter is true. This does require moving the call to the git module out of deps.pp into init.pp as you cannot pass parameters to a base class via inherits.