### PR TITLE
Fix Exec git-clone-rbenv permission denied issue

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,7 @@ class rbenv (
   exec { 'git-clone-rbenv':
     command => "/usr/bin/git clone ${rbenv::repo_path} ${install_dir}",
     creates => $install_dir,
+    cwd     => '/',
     user    => $owner,
     require => Package['git'],
   }


### PR DESCRIPTION
Hi there,

I've ran into the following issue when attempting to use this module:

```
Notice: /Stage[main]/Rbenv/Exec[git-clone-rbenv]/returns: fatal: Could not change back to '/home/vagrant': Permission denied
Error: /usr/bin/git clone https://github.com/sstephenson/rbenv.git /var/lib/jenkins/.rbenv returned 128 instead of one of [0]
Error: /Stage[main]/Rbenv/Exec[git-clone-rbenv]/returns: change from notrun to 0 failed: /usr/bin/git clone https://github.com/sstephenson/rbenv.git /var/lib/jenkins/.rbenv returned 128 instead of one of [0]
```

Puppet attempts to run an exec command from [the current directory](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/provider/exec.rb#L24).

I believe that, if the current directory is inaccessible to the user the command runs as, a permission denied error is thrown.

This PR changes the current directory to be '/', which is accessible to all the users.