### PR TITLE
Ensure that bzip2 is installed

### DIFF
--- a/manifests/deps/redhat.pp
+++ b/manifests/deps/redhat.pp
@@ -6,6 +6,7 @@ class rbenv::deps::redhat {
 
   ensure_packages([
     'binutils',
+    'bzip2',
     'gcc',
     'gcc-c++',
     'git',


### PR DESCRIPTION
Recent changes in ruby-build plugin require bzip2 package, which is not installed by default in EL distros.

https://github.com/rbenv/ruby-build/issues/870