### PR TITLE
Fix test command not to run fetch-rbenv anytime puppet runs when version is set.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,7 +132,7 @@ class rbenv (
       cwd         => $install_dir,
       user        => $owner,
       environment => $env,
-      unless      => "/usr/bin/test $(/usr/bin/git describe --tags) == '${version}'",
+      unless      => "/usr/bin/test $(/usr/bin/git describe --tags) = '${version}'",
       require     => File[$install_dir],
     } ~>
     exec { 'update-rbenv':


### PR DESCRIPTION
When `rbenv` class is included the following way, puppet runs are not idempotent anymore. It looks like `unless` condition of `exec` resource fails:

```puppet
    class { '::rbenv':
        install_dir => '/opt/rbenv/rbenv-0.4.0',
        version     => 'v0.4.0',
    }
```

This PR changes a bit the way how test is performed.. Basically version vould always be string as rbenv is tagged according to pattern: `v$RBENV_VERSION`, so I believe using single equal mark will do here. At least this is what my `test` manual is saying:

```
       STRING1 = STRING2
              the strings are equal
```

Please do let me know if any firther clarification is required.