### PR TITLE
add gem version string to exec resource for uniqueness

### DIFF
--- a/manifests/gem.pp
+++ b/manifests/gem.pp
@@ -71,8 +71,9 @@ define rbenv::gem(
   }
 
   $environment_for_install = concat(["RBENV_ROOT=${install_dir}"], $env)
+  $version_for_exec_name = regsubst($version, '[^0-9]+', '_', 'EG')
 
-  exec { "gem-install-${gem}-${ruby_version}":
+  exec { "ruby-${ruby_version}-gem-install-${gem}-${version_for_exec_name}":
     command => "gem install ${gem} --version '${version}' ${docs}",
     unless  => "gem list ${gem} --installed --version '${version}'",
     path    => [
@@ -84,11 +85,11 @@ define rbenv::gem(
     ],
     timeout => $timeout
   }~>
-  exec { "rbenv-rehash-${gem}-${ruby_version}":
+  exec { "rbenv-rehash-${gem}-${ruby_version}-${version_for_exec_name}":
     command     => "${install_dir}/bin/rbenv rehash",
     refreshonly => true,
   }~>
-  exec { "rbenv-permissions-${gem}-${ruby_version}":
+  exec { "rbenv-permissions-${gem}-${ruby_version}-${version_for_exec_name}":
     command     => "/bin/chown -R ${rbenv::owner}:${rbenv::group} \
                   ${install_dir}/versions/${ruby_version}/lib/ruby/gems && \
                   /bin/chmod -R g+w \

--- a/spec/defines/gem_spec.rb
+++ b/spec/defines/gem_spec.rb
@@ -14,8 +14,8 @@ describe 'rbenv::gem' do
     end
 
     it { should contain_class('rbenv') }
-    it { should contain_exec("gem-install-bundler-2.0.0-p247") }
-    it { should contain_exec("rbenv-rehash-bundler-2.0.0-p247") }
-    it { should contain_exec("rbenv-permissions-bundler-2.0.0-p247") }
+    it { should contain_exec("ruby-2.0.0-p247-gem-install-bundler-1_3_5") }
+    it { should contain_exec("rbenv-rehash-bundler-2.0.0-p247-1_3_5") }
+    it { should contain_exec("rbenv-permissions-bundler-2.0.0-p247-1_3_5") }
   end
 end


### PR DESCRIPTION
hey @justindowning thanks for the module.  I came across the issue of trying to upgrade some base gems in preparation for a ruby upgrade...specifically bundler in ruby 2.1.5 in preparation to upgrade to ruby 2.3.3.  So I attempted to add bundler version 1.13.6 to ruby 2.1.5 but it failed on duplicate resource, like so:
```
Duplicate declaration: Exec[gem-install-bundler-2.1.5] is already declared in file /etc/puppet/environments/dev/modules/rbenv/manifests/gem.pp:86; cannot redeclare at /etc/puppet/environments/dev/modules/rbenv/manifests/gem.pp:86
```

I think this PR addresses it safely, but it was like a ten minute effort.  Let me know if some more thought should be put into it.  Thanks!