### PR TITLE
Add dependencies for yacc, autoconf and subversion

### DIFF
--- a/manifests/deps/debian.pp
+++ b/manifests/deps/debian.pp
@@ -4,6 +4,8 @@
 #
 class rbenv::deps::debian {
   ensure_packages([
+    'autoconf',
+    'bison',
     'build-essential',
     'git',
     'libreadline6-dev',
@@ -14,6 +16,7 @@ class rbenv::deps::debian {
     'libncurses5-dev',
     'libgdbm3',
     'libgdbm-dev',
-    'patch'
+    'patch',
+    'subversion'
     ])
 }

--- a/manifests/deps/redhat.pp
+++ b/manifests/deps/redhat.pp
@@ -5,7 +5,9 @@
 class rbenv::deps::redhat {
 
   ensure_packages([
+    'autoconf',
     'binutils',
+    'byacc',
     'bzip2',
     'gcc',
     'gcc-c++',
@@ -18,6 +20,7 @@ class rbenv::deps::redhat {
     'libyaml-devel',
     'ncurses-devel',
     'gdbm-devel',
-    'patch'
+    'patch',
+    'subversion'
     ])
 }

--- a/manifests/deps/suse.pp
+++ b/manifests/deps/suse.pp
@@ -6,9 +6,11 @@ class rbenv::deps::suse {
 
   ensure_packages([
     'binutils',
+    'bsion',
     'gcc',
     'git',
     'automake',
+    'autoconf',
     'openssl-devel',
     'readline-devel',
     'zlib-devel',
@@ -16,6 +18,7 @@ class rbenv::deps::suse {
     'libyaml-devel',
     'ncurses-devel',
     'gdbm-devel',
-    'patch'
+    'patch',
+    'subversion'
   ])
 }


### PR DESCRIPTION
I needed to install some older Rubies (e.g. `1.8.7-p375`) and discovered that there were some additional dependencies required.

This pull request adds these packages to the dependency classes. 