### PR TITLE
Add manage_profile parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,11 @@
 #   Default: true
 #   This variable is optional.
 #
+# [$manage_profile]
+#   Toggles the option to let the module install rbenv.sh into /etc/profile.d.
+#   Default: true
+#   This variable is optional.
+#
 # === Requires
 #
 # This module requires the following modules:
@@ -70,14 +75,15 @@
 # Copyright 2013 Justin Downing
 #
 class rbenv (
-  $repo_path   = 'https://github.com/rbenv/rbenv.git',
-  $install_dir = '/usr/local/rbenv',
-  $owner       = 'root',
-  $group       = $rbenv::params::group,
-  $latest      = false,
-  $version     = undef,
-  $env         = [],
-  $manage_deps = true,
+  $repo_path      = 'https://github.com/rbenv/rbenv.git',
+  $install_dir    = '/usr/local/rbenv',
+  $owner          = 'root',
+  $group          = $rbenv::params::group,
+  $latest         = false,
+  $version        = undef,
+  $env            = [],
+  $manage_deps    = true,
+  $manage_profile = true,
 ) inherits rbenv::params {
 
   validate_array($env)
@@ -106,10 +112,12 @@ class rbenv (
     mode   => '0775',
   }
 
-  file { '/etc/profile.d/rbenv.sh':
-    ensure  => file,
-    content => template('rbenv/rbenv.sh'),
-    mode    => '0775'
+  if $manage_profile {
+    file { '/etc/profile.d/rbenv.sh':
+      ensure  => file,
+      content => template('rbenv/rbenv.sh'),
+      mode    => '0775'
+    }
   }
 
   # run `git pull` on each run if we want to keep rbenv updated


### PR DESCRIPTION
This commit adds a manage_profile parameter that makes the distribution of a profile.d snippet optional. It defaults to true to maintain current behaviour.

There are potential use cases where you may not want to initialise `rbenv` for every login shell by default, but still offer a global, centrally managed installation.

