### PR TITLE
Adjust exec path order in build.pp

### DIFF
--- a/manifests/build.pp
+++ b/manifests/build.pp
@@ -108,12 +108,12 @@ define rbenv::build (
     timeout     => 1800,
     environment => $environment_for_build,
     path        => [
+      "${install_dir}/bin/",
+      "${install_dir}/shims/",
       '/bin/',
       '/sbin/',
       '/usr/bin/',
-      '/usr/sbin/',
-      "${install_dir}/bin/",
-      "${install_dir}/shims/"
+      '/usr/sbin/'
     ],
   }
 


### PR DESCRIPTION
This commit ensures that the module's `bin` and `shims` directories are at the top of the path for the various `exec`s in `build.pp`.

We were migrating to use this module on a system with `rbenv` installed via a package manager and this change was necessary to ensure we ran the correct version when building rubies for the module during the migration period. This may be an edge case but I don't believe this will have any negative results and it may be useful for others doing a migration like ours.