### PR TITLE
Add option to update rbenv via cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,15 @@ Plugins can be installed from GitHub using the following definiton:
 
     rbenv::plugin { 'github_user/github_repo': }
 
-You can ensure a plugin is kept up-to-date. This is helpful for a plugin like
-`ruby-build` so that definitions are always available:
+You can ensure a plugin is kept up-to-date during puppet runs. This is 
+helpful for a plugin like `ruby-build` so that definitions are always 
+available:
 
     rbenv::plugin { 'rbenv/ruby-build': latest => true }
+
+This can also be achieved via cron.  
+
+    rbenv::plugin { 'rbenv/ruby-build': latestcron => true }
 
 ## Gems
 Gems can be installed too! You *must* specify the `ruby_version` you want to

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -9,9 +9,22 @@
 #   This variable is required.
 #
 # [$latest]
-#   This defines whether the plugin is kept up-to-date.
+#   This defines whether the plugin is kept up-to-date during a puppet run.
 #   Defaults: false
-#   This vaiable is optional.
+#   This variable is optional.
+#
+# [$latestcron]
+#   This defines whether the plugin is kept up-to-date via cron.
+#   Defaults: false
+#   This variable is optional
+# 
+# [$handleoutput]
+#  This is used with cron
+#  Default: >/dev/null 2>&1 (only output on error)
+#
+# [$day] [$hour] [$minute] [$weekday]
+#  Specify runtime of cron if configured as per https://docs.puppet.com/puppet/latest/types/cron.html
+#   Defaults: Sunday
 #
 # [$env]
 #   This is used to set environment variables when installing plugins.
@@ -31,9 +44,12 @@
 # Justin Downing <justin@downing.us>
 #
 define rbenv::plugin(
-  $install_dir = $rbenv::install_dir,
-  $latest      = false,
-  $env         = $rbenv::env,
+  $install_dir  = $rbenv::install_dir,
+  $latest       = false,
+  $latestcron   = false,
+  $handleoutput = '>/dev/null 2>&1',
+  $weekday      = 'Sunday',
+  $env          = $rbenv::env,
 ) {
   include rbenv
 
@@ -61,6 +77,17 @@ define rbenv::plugin(
       cwd     => "${install_dir}/plugins/${plugin[1]}",
       user    => $rbenv::owner,
       onlyif  => "/usr/bin/test -d ${install_dir}/plugins/${plugin[1]}",
+    }
+  }
+  # run `git pull` via cron to keep the plugin updated
+  if $latestcron == true {
+    cron { "rbenv-update-${name}":
+      command  => "cd ${install_dir}/plugins/${plugin[1]} ; /usr/bin/git pull ${handleoutput}",
+      user     => $rbenv::owner,
+      monthday => $day,
+      weekday  => $weekday,
+      hour     => $hour,
+      minute   => $minute,
     }
   }
 }


### PR DESCRIPTION
$latestcron
 - This gives the option of keeping rbenv updated via cron 

 - This is using the same logic that $latest does, but we use the cron resource rather than exec
 - Day/Hour/Minute/Week cron resource statements will work here. By default it runs on Sunday
 - By default we only output on error, this also can be removed/reconfigured.