### PR TITLE
Debian fixes & linting

### DIFF
--- a/manifests/build.pp
+++ b/manifests/build.pp
@@ -92,8 +92,8 @@ define rbenv::build (
         ensure  => directory,
         recurse => true,
         before  => File[$patch_file],
-      }->
-      file { $patch_file:
+      }
+      -> file { $patch_file:
         ensure => file,
         source => $patch,
       }
@@ -127,20 +127,20 @@ define rbenv::build (
     user    => 'root',
     unless  => "test -d ${install_dir}/versions/${title}",
     require => Class['rbenv'],
-  }->
-  exec { "git-pull-rubybuild-${title}":
+  }
+  -> exec { "git-pull-rubybuild-${title}":
     command => 'git reset --hard HEAD && git pull',
     cwd     => "${install_dir}/plugins/ruby-build",
     user    => 'root',
     unless  => "test -d ${install_dir}/versions/${title}",
     require => Rbenv::Plugin['rbenv/ruby-build'],
-  }->
-  exec { "rbenv-install-${title}":
+  }
+  -> exec { "rbenv-install-${title}":
     # patch file must be read from stdin only if supplied
     command => sprintf("rbenv install ${title}${install_options}%s", $patch ? { undef => '', false => '', default => " < ${patch_file}" }),
     creates => "${install_dir}/versions/${title}",
-  }~>
-  exec { "rbenv-ownit-${title}":
+  }
+  ~> exec { "rbenv-ownit-${title}":
     command     => "chown -R ${owner}:${group} \
                     ${install_dir}/versions/${title} && \
                     chmod -R g+w ${install_dir}/versions/${title}",

--- a/manifests/deps/debian.pp
+++ b/manifests/deps/debian.pp
@@ -6,7 +6,7 @@ class rbenv::deps::debian {
   ensure_packages([
     'build-essential',
     'git',
-    'libreadline6-dev',
+    'libreadline-dev',
     'libssl-dev',
     'zlib1g-dev',
     'libffi-dev',

--- a/manifests/gem.pp
+++ b/manifests/gem.pp
@@ -61,7 +61,7 @@ define rbenv::gem(
   $skip_docs    = false,
   $timeout      = 300,
   $env          = $rbenv::env,
-  $source       = "https://rubygems.org/"
+  $source       = 'https://rubygems.org/'
 ) {
   include rbenv
 
@@ -89,12 +89,12 @@ define rbenv::gem(
       '/sbin'
     ],
     timeout => $timeout
-  }~>
-  exec { "ruby-${ruby_version}-rbenv-rehash-${gem}-${version_for_exec_name}":
+  }
+  ~> exec { "ruby-${ruby_version}-rbenv-rehash-${gem}-${version_for_exec_name}":
     command     => "${install_dir}/bin/rbenv rehash",
     refreshonly => true,
-  }~>
-  exec { "ruby-${ruby_version}-rbenv-permissions-${gem}-${version_for_exec_name}":
+  }
+  ~> exec { "ruby-${ruby_version}-rbenv-permissions-${gem}-${version_for_exec_name}":
     command     => "/bin/chown -R ${rbenv::owner}:${rbenv::group} \
                   ${install_dir}/versions/${ruby_version}/lib/ruby/gems && \
                   /bin/chmod -R g+w \

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -129,8 +129,8 @@ class rbenv (
       environment => $env,
       onlyif      => '/usr/bin/test $(git rev-parse --abbrev-ref HEAD) != "master"',
       require     => File[$install_dir],
-    } ->
-    exec { 'update-rbenv':
+    }
+    -> exec { 'update-rbenv':
       command     => '/usr/bin/git pull',
       cwd         => $install_dir,
       user        => $owner,
@@ -145,8 +145,8 @@ class rbenv (
       user        => $owner,
       environment => $env,
       require     => File[$install_dir],
-    } ~>
-    exec { 'update-rbenv':
+    }
+    ~> exec { 'update-rbenv':
       command     => "/usr/bin/git checkout ${version}",
       cwd         => $install_dir,
       user        => $owner,

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -46,8 +46,8 @@ define rbenv::plugin(
     cwd     => "${install_dir}/plugins",
     onlyif  => "/usr/bin/test -d ${install_dir}/plugins",
     unless  => "/usr/bin/test -d ${install_dir}/plugins/${plugin[1]}",
-  }~>
-  exec { "rbenv-permissions-${name}":
+  }
+  ~> exec { "rbenv-permissions-${name}":
     command     => "/bin/chown -R ${rbenv::owner}:${rbenv::group} \
                     ${install_dir} && \
                     /bin/chmod -R g+w ${install_dir}",

--- a/tests/build.pp
+++ b/tests/build.pp
@@ -1,3 +1,3 @@
-class { 'rbenv': }->
-rbenv::plugin { 'rbenv/ruby-build': }->
-rbenv::build { '2.0.0-p247': global => true }
+class { 'rbenv': }
+-> rbenv::plugin { 'rbenv/ruby-build': }
+-> rbenv::build { '2.0.0-p247': global => true }

--- a/tests/gem.pp
+++ b/tests/gem.pp
@@ -1,8 +1,8 @@
-package { ['git', 'build-essential']: ensure => 'installed' }->
-class { 'rbenv': }->
-rbenv::plugin { 'rbenv/ruby-build': }->
-rbenv::build { '2.0.0-p247': global => true }->
-rbenv::gem { 'thor':
+package { ['git', 'build-essential']: ensure => 'installed' }
+-> class { 'rbenv': }
+-> rbenv::plugin { 'rbenv/ruby-build': }
+-> rbenv::build { '2.0.0-p247': global => true }
+-> rbenv::gem { 'thor':
   version      => '0.18.1',
   ruby_version => '2.0.0-p247'
 }

--- a/tests/plugin.pp
+++ b/tests/plugin.pp
@@ -1,3 +1,3 @@
-package { 'git': ensure => 'installed' }->
-class { 'rbenv': }->
-rbenv::plugin { 'rbenv/ruby-build': }
+package { 'git': ensure => 'installed' }
+-> class { 'rbenv': }
+-> rbenv::plugin { 'rbenv/ruby-build': }

--- a/tests/rbenv-vars.pp
+++ b/tests/rbenv-vars.pp
@@ -1,3 +1,3 @@
-package { 'git': ensure => 'installed' }->
-class { 'rbenv': }->
-rbenv::plugin { 'rbenv/rbenv-vars': }
+package { 'git': ensure => 'installed' }
+-> class { 'rbenv': }
+-> rbenv::plugin { 'rbenv/rbenv-vars': }


### PR DESCRIPTION
On Debian, 'libreadline6-dev' does not exist, but instead resolves to 'libreadline-dev'. This causes Puppet runs to not fully converge in otherwise no-op situations on modern Debian hosts.

My guess is that this was defined as such due to an old Rails bug that, I think, is no longer an issue.

Also, I puppet-lint -f 'd everything. :)