### PR TITLE
Quiet plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gem 'rake'
 gem 'librarian-puppet'

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -61,6 +61,7 @@ define rbenv::plugin(
       cwd     => "${install_dir}/plugins/${plugin[1]}",
       user    => $rbenv::owner,
       onlyif  => "/usr/bin/test -d ${install_dir}/plugins/${plugin[1]}",
+      unless  => '/usr/bin/git fetch --quiet; /usr/bin/test $(git rev-parse HEAD) == $(git rev-parse @{u})',
     }
   }
 }


### PR DESCRIPTION
This PR will stop the update plugin exec from always doing a pull and creating a notice in the puppet run.

It also allows an alternate gem source so to make it easier for me to test.